### PR TITLE
Speed up extraction of compressed PBO data

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -11,6 +11,9 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10-dev"]
         architecture: [x86, x64]
+        exclude:
+          - os: ubuntu-latest
+            architecture: x86
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -14,6 +14,8 @@ jobs:
         exclude:
           - os: ubuntu-latest
             architecture: x86
+          - os: macos-latest
+            architecture: x86
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -10,13 +10,15 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10-dev"]
+        architecture: [x86, x64]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.architecture }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.architecture }}
     - name: Install dependencies
       run: |
         pip install -r dev-requirements.txt

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,8 +1,6 @@
 name: Upload Python Package
 
-on:
-  release:
-    types: [created]
+on: [push]
 
 jobs:
   build:
@@ -59,9 +57,3 @@ jobs:
         python setup.py sdist
         cp artifacts/artifact/* dist
         ls -lR dist
-    - name: Publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload dist/*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,35 @@ on:
     types: [created]
 
 jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.8", "3.9"]
+        architecture: [x86, x64]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.architecture }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.architecture }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools
+    - name: Build wheel
+      run: |
+        python setup.py bdist_wheel
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*
+
   deploy:
+    needs: build
+
     runs-on: ubuntu-latest
 
     steps:
@@ -16,10 +44,15 @@ jobs:
         python-version: '3.9'
     - name: Install dependencies
       run: |
+        python -m pip install --upgrade pip setuptools
         pip install twine
+    - uses: actions/download-artifact@v2
+      with:
+        path: artifacts
     - name: Build sdist
       run: |
         python setup.py sdist
+        cp artifacts/artifact/* dist
         ls -lR dist
     - name: Publish
       env:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,6 +13,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9"]
         architecture: [x86, x64]
+        exclude:
+          - os: ubuntu-latest
+            architecture: x86
+          - os: macos-latest
+            architecture: x86
 
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +28,7 @@ jobs:
         architecture: ${{ matrix.architecture }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
+        pip install -r dev-requirements.txt
     - name: Build wheel
       run: |
         python setup.py bdist_wheel

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,6 +1,8 @@
 name: Upload Python Package
 
-on: [push]
+on:
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -57,3 +59,9 @@ jobs:
         python setup.py sdist
         cp artifacts/artifact/* dist
         ls -lR dist
+    - name: Publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload dist/*

--- a/dayz_dev_tools/expand.py
+++ b/dayz_dev_tools/expand.py
@@ -1,31 +1,10 @@
-import math
-
 from dayz_dev_tools import pbo_file_reader
+import dayz_dev_tools_ext  # type: ignore[import]
 
 
-def expand(reader: pbo_file_reader.PBOFileReader) -> bytes:
-    result = b""
+def expand(reader: pbo_file_reader.PBOFileReader, outsize: int) -> bytes:
+    inbuffer = reader.read(reader.size)
+    outbuffer = bytearray(outsize)
+    dayz_dev_tools_ext.expand(outbuffer, inbuffer)
 
-    while not reader.eof():
-        flagbits = reader.read(1)[0]
-
-        for bit in range(8):
-            if reader.eof():
-                break
-
-            if flagbits >> bit & 1 == 1:
-                result += reader.read(1)
-            else:
-                pointer = reader.readuword()
-                rpos = len(result) - ((pointer & 0xff) + ((pointer & 0xf000) >> 4))
-                rlen = ((pointer >> 8) & 0xf) + 3
-
-                if rpos < 0:
-                    result += bytes(b" " * rlen)
-                elif rpos + rlen > len(result):
-                    chunk = result[rpos:]
-                    result += (chunk * math.ceil(rlen / len(chunk)))[:rlen]
-                else:
-                    result += result[rpos:rpos + rlen]
-
-    return result
+    return bytes(outbuffer)

--- a/dayz_dev_tools/pbo_file.py
+++ b/dayz_dev_tools/pbo_file.py
@@ -34,7 +34,8 @@ class PBOFile:
             self.content_reader.seek(self.data_size - 4)
             expected_checksum = self.content_reader.readuint()
 
-            expanded = expand.expand(self.content_reader.subreader(0, self.data_size - 4))
+            expanded = expand.expand(
+                self.content_reader.subreader(0, self.data_size - 4), self.original_size)
 
             actual_checksum = sum(expanded)
 

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,12 @@ setuptools.setup(
             "unpbo=dayz_dev_tools.unpbo:main",
             "run-server=dayz_dev_tools.run_server:main"
         ]
-    })
+    },
+    ext_modules=[
+        setuptools.Extension(
+            name="dayz_dev_tools_ext",
+            sources=[
+                "src/dayz_dev_tools_ext.c"
+            ]
+        )
+    ])

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "Typing :: Typed"
     ],
     python_requires=">=3.8",
+    setup_requires=["wheel"],
     install_requires=[
         "jsonschema>=3.2.0",
         "toml>=0.10.2"

--- a/src/dayz_dev_tools_ext.c
+++ b/src/dayz_dev_tools_ext.c
@@ -1,7 +1,6 @@
 #define PY_SSIZE_T_CLEAN
 
 #include <Python.h>
-#include <stdio.h>
 
 static void
 get_pointer(Py_ssize_t *rpos, Py_ssize_t *rlen, Py_ssize_t outlen, unsigned short raw)

--- a/src/dayz_dev_tools_ext.c
+++ b/src/dayz_dev_tools_ext.c
@@ -58,14 +58,11 @@ expand_impl(unsigned char *outb, Py_ssize_t outlen, const unsigned char *inb, Py
                         }
                     }
                 }
-                else if (((outidx + rlen) <= outlen) && ((rpos + rlen) <= outlen))
-                {
-                    memcpy(&outb[outidx], &outb[rpos], rlen);
-                    outidx += rlen;
-                }
                 else
                 {
-                    return -1;
+                    cpyend = Py_MIN(rlen, outlen - outidx);
+                    memcpy(&outb[outidx], &outb[rpos], cpyend);
+                    outidx += cpyend;
                 }
             }
         }

--- a/src/dayz_dev_tools_ext.c
+++ b/src/dayz_dev_tools_ext.c
@@ -1,0 +1,117 @@
+#define PY_SSIZE_T_CLEAN
+
+#include <Python.h>
+#include <stdio.h>
+
+static void
+get_pointer(Py_ssize_t *rpos, Py_ssize_t *rlen, Py_ssize_t outlen, unsigned short raw)
+{
+    *rpos = outlen - ((raw & 0xff) + ((raw & 0xf000) >> 4));
+    *rlen = ((raw >> 8) & 0xf) + 3;
+}
+
+static int
+expand_impl(unsigned char *outb, Py_ssize_t outlen, const unsigned char *inb, Py_ssize_t inlen)
+{
+    Py_ssize_t outidx = 0;
+    Py_ssize_t inidx = 0;
+    Py_ssize_t rpos, rlen;
+    Py_ssize_t cpypos, cpyend;
+    int bit, cnt;
+    unsigned char flagbits;
+
+    while (inidx < inlen)
+    {
+        flagbits = inb[inidx++];
+
+        for (bit = 0; (bit < 8) && (inidx < inlen) && (outidx < outlen); ++bit)
+        {
+            if (flagbits >> bit & 1)
+            {
+                outb[outidx++] = inb[inidx++];
+            }
+            else if (inidx < inlen - 1)
+            {
+                get_pointer(&rpos, &rlen, outidx, inb[inidx + 1] << 8 | inb[inidx]);
+                inidx += 2;
+
+                if (rpos < 0)
+                {
+                    for (cnt = 0; (cnt < rlen) && (outidx < outlen); ++outidx)
+                    {
+                        outb[outidx] = ' ';
+                    }
+                }
+                else if ((rpos + rlen) > outidx)
+                {
+                    cpyend = outidx + rlen;
+                    if (cpyend > outlen)
+                    {
+                        break;
+                    }
+
+                    while (outidx < cpyend)
+                    {
+                        for (cpypos = rpos; (cpypos < outlen) && (outidx < cpyend); ++cpypos)
+                        {
+                            outb[outidx++] = outb[cpypos];
+                        }
+                    }
+                }
+                else if (((outidx + rlen) <= outlen) && ((rpos + rlen) <= outlen))
+                {
+                    memcpy(&outb[outidx], &outb[rpos], rlen);
+                    outidx += rlen;
+                }
+                else
+                {
+                    return -1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+static PyObject *
+dayz_dev_tools_ext_expand(PyObject *self, PyObject *args)
+{
+    Py_buffer outbuffer;
+    Py_buffer inbuffer;
+
+    if (!PyArg_ParseTuple(args, "w*y*", &outbuffer, &inbuffer))
+    {
+        return NULL;
+    }
+
+    if (expand_impl(
+                (unsigned char *)outbuffer.buf, outbuffer.len,
+                (unsigned const char *)inbuffer.buf, inbuffer.len))
+    {
+        PyErr_SetString(
+                PyExc_BufferError, "Unexpectedly reached end of output buffer in PBO expand");
+        return NULL;
+    }
+
+    return Py_None;
+}
+
+static PyMethodDef ExtMethods[] = {
+    {"expand", dayz_dev_tools_ext_expand, METH_VARARGS, "Expand a compressed buffer"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef ext_module = {
+    PyModuleDef_HEAD_INIT,
+    "dayz_dev_tools_ext",
+    NULL,
+    -1,
+    ExtMethods
+};
+
+PyMODINIT_FUNC
+PyInit_dayz_dev_tools_ext(void)
+{
+    return PyModule_Create(&ext_module);
+}

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -44,7 +44,7 @@ class TestExpand(unittest.TestCase):
 
         outbytes = expand.expand(infile, 10)
 
-        assert outbytes == b"ABCDEFGH\0\0"
+        assert outbytes == b"ABCDEFGHBC"
 
     def test_inserts_spaces_when_compressed_data_references_negative_offset(self) -> None:
         inbytes = b"\x0fABCD\x05\x0f"

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -10,7 +10,7 @@ class TestExpand(unittest.TestCase):
         inbytes = b"\xffABCDEFGH\xffIJKLMNOP\xffQRSTUVWX"
         infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
 
-        outbytes = expand.expand(infile)
+        outbytes = expand.expand(infile, 24)
 
         assert outbytes == b"ABCDEFGHIJKLMNOPQRSTUVWX"
 
@@ -18,7 +18,15 @@ class TestExpand(unittest.TestCase):
         inbytes = b"\xffABCDE"
         infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
 
-        outbytes = expand.expand(infile)
+        outbytes = expand.expand(infile, 5)
+
+        assert outbytes == b"ABCDE"
+
+    def test_stops_extracting_bytes_when_end_of_output_buffer_is_reached(self) -> None:
+        inbytes = b"\xffABCDEFGH\xffIJKLMNOP\xffQRSTUVWX"
+        infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
+
+        outbytes = expand.expand(infile, 5)
 
         assert outbytes == b"ABCDE"
 
@@ -26,23 +34,39 @@ class TestExpand(unittest.TestCase):
         inbytes = b"\xffABCDEFGH\0\x07\x01"
         infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
 
-        outbytes = expand.expand(infile)
+        outbytes = expand.expand(infile, 12)
 
         assert outbytes == b"ABCDEFGHBCDE"
+
+    def test_does_not_overflow_output_size_when_expanding_previously_compressed_data(self) -> None:
+        inbytes = b"\xffABCDEFGH\0\x07\x01"
+        infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
+
+        outbytes = expand.expand(infile, 10)
+
+        assert outbytes == b"ABCDEFGH\0\0"
 
     def test_inserts_spaces_when_compressed_data_references_negative_offset(self) -> None:
         inbytes = b"\x0fABCD\x05\x0f"
         infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
 
-        outbytes = expand.expand(infile)
+        outbytes = expand.expand(infile, 22)
 
         assert outbytes == b"ABCD                  "
+
+    def test_stops_inserting_spaces_when_end_of_output_buffer_is_reached(self) -> None:
+        inbytes = b"\x0fABCD\x05\x0f"
+        infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
+
+        outbytes = expand.expand(infile, 10)
+
+        assert outbytes == b"ABCD      "
 
     def test_repeats_previous_data_when_length_extends_beyond_end_of_data(self) -> None:
         inbytes = b"\x0fABCD\x02\x07"
         infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
 
-        outbytes = expand.expand(infile)
+        outbytes = expand.expand(infile, 14)
 
         assert outbytes == b"ABCDCDCDCDCDCD"
 
@@ -50,6 +74,6 @@ class TestExpand(unittest.TestCase):
         inbytes = b"\x0fABCD\x02\x08"
         infile = pbo_file_reader.PBOFileReader(io.BytesIO(inbytes), 0, len(inbytes))
 
-        outbytes = expand.expand(infile)
+        outbytes = expand.expand(infile, 15)
 
         assert outbytes == b"ABCDCDCDCDCDCDC"


### PR DESCRIPTION
Fixes #1 by rewriting the critical path in native C code.

This also updates the publish-to-PyPI workflow to publish wheels so that, in most cases, users don't have to build the native code when installing the package, since doing so can be particularly cumbersome on Windows.