### PR TITLE
Enable extra command line parameters to be passed to DayZ Server

### DIFF
--- a/dayz_dev_tools/launch_settings.py
+++ b/dayz_dev_tools/launch_settings.py
@@ -17,6 +17,7 @@ class LaunchSettings:
     _mods: typing.List[str]
     _server_mods: typing.List[str]
     _mission: typing.Optional[str]
+    _parameters: typing.List[str]
     _bundles: typing.Dict[str, server_config.BundleConfig]
 
     def __init__(self, config: server_config.ServerConfig) -> None:
@@ -34,6 +35,7 @@ class LaunchSettings:
         self._mods = []
         self._server_mods = []
         self._mission = config.mission_directory
+        self._parameters = []
         self._bundles = config.bundles
 
         try:
@@ -168,6 +170,22 @@ class LaunchSettings:
         """
         self._mission = name
 
+    def parameters(self) -> typing.List[str]:
+        """Get extra command line parameters to pass to DayZ Server.
+
+        :Returns:
+          The list of extra command line parameters to pass to DayZ Server.
+        """
+        return self._parameters
+
+    def add_parameter(self, param: str) -> None:
+        """Add extra parameter to pass on the DayZ Server command line.
+
+        :Parameters:
+          - `param`: The parameter to pass on the DayZ Server command line.
+        """
+        self._parameters.append(param)
+
     def load_bundle(self, name: str) -> None:
         """Load a bundle to configure DayZ Server launch settings.
 
@@ -212,3 +230,6 @@ def _config_bundle(bundle: server_config.BundleConfig, settings: LaunchSettings)
 
     if bundle.mission_directory is not None:
         settings.set_mission_directory(bundle.mission_directory)
+
+    for param in bundle.parameters:
+        settings.add_parameter(param)

--- a/dayz_dev_tools/launch_settings.py
+++ b/dayz_dev_tools/launch_settings.py
@@ -35,7 +35,7 @@ class LaunchSettings:
         self._mods = []
         self._server_mods = []
         self._mission = config.mission_directory
-        self._parameters = []
+        self._parameters = config.parameters
         self._bundles = config.bundles
 
         try:

--- a/dayz_dev_tools/run_server.py
+++ b/dayz_dev_tools/run_server.py
@@ -56,6 +56,8 @@ def run_server(
         args.append(
             _mod_parameter("servermod", settings.server_mods(), settings.workshop_directory()))
 
+    args.extend(settings.parameters())
+
     logging.info(f"Running server with: {args}")
 
     if wait:

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -82,6 +82,7 @@ file. For example:
    profile_directory = "profile"
    mission_directory = 'mpmissions\dayzoffline.enoch'
    bundles = 'path\to\module.py'
+   parameters = [ '-opt1', '-opt2=value' ]
 
    [workshop]
    directory = 'E:\DayZ\Workshop'
@@ -151,6 +152,17 @@ By default, ``run-server`` will look for bundles in a Python file named
 Bundles can also be loaded from the ``run-server`` config file, as described
 below.
 
+Extra Parameters
+""""""""""""""""
+
+Use the ``parameters`` key to pass extra command line parameters to DayZ
+Server. For example, to enable admin logs:
+
+.. code:: toml
+
+   [server]
+   parameters = [ '-adminLog' ]
+
 DayZ Workshop Directory
 """""""""""""""""""""""
 
@@ -179,6 +191,7 @@ named ``example``:
    profile_directory = 'path\to\profile'
    mission_directory = 'path\to\mission'
    workshop_directory = 'path\to\workshop'
+   parameters = [ '-extraParam', '-another=arg' ]
 
 These settings work the same as the ones of the same names described in
 `Configuration File`_. In addition, bundles can define DayZ mods and server

--- a/tests/test_launch_settings.py
+++ b/tests/test_launch_settings.py
@@ -18,6 +18,7 @@ class TestLaunchSettings(unittest.TestCase):
             config="config.cfg",
             workshop_directory="workshop/dir",
             bundle_path=BUNDLE_PATH,
+            parameters=["-extraParam"],
             bundles={
                 "override_all": server_config.BundleConfig(
                     executable="OVERRIDDEN-EXE",
@@ -144,7 +145,7 @@ class TestLaunchSettings(unittest.TestCase):
     def test_parameters_returns_parameters_from_config(self) -> None:
         settings = launch_settings.LaunchSettings(self.config)
 
-        assert settings.parameters() == []
+        assert settings.parameters() == ["-extraParam"]
 
     def test_parameters_returns_parameters_added_with_add_parameter(self) -> None:
         settings = launch_settings.LaunchSettings(self.config)
@@ -152,7 +153,7 @@ class TestLaunchSettings(unittest.TestCase):
         settings.add_parameter("-opt1")
         settings.add_parameter("-opt2=value")
 
-        assert settings.parameters() == ["-opt1", "-opt2=value"]
+        assert settings.parameters() == ["-extraParam", "-opt1", "-opt2=value"]
 
     def test_load_bundle_loads_bundle_from_config_when_present_in_config(self) -> None:
         settings = launch_settings.LaunchSettings(self.config)
@@ -166,7 +167,7 @@ class TestLaunchSettings(unittest.TestCase):
         assert settings.mods() == ["mod1", "mod2", "mod3"]
         assert settings.server_mods() == ["mod4", "mod5", "mod6"]
         assert settings.mission_directory() == "OVERRIDDEN-MISSION"
-        assert settings.parameters() == ["-opt1", "-opt2=value"]
+        assert settings.parameters() == ["-extraParam", "-opt1", "-opt2=value"]
 
     def test_load_bundle_from_config_only_sets_settings_in_config(self) -> None:
         settings = launch_settings.LaunchSettings(self.config)

--- a/tests/test_launch_settings.py
+++ b/tests/test_launch_settings.py
@@ -26,7 +26,8 @@ class TestLaunchSettings(unittest.TestCase):
                     workshop_directory="OVERRIDDEN-WORKSHOP",
                     mods=["mod1", "mod2", "mod3"],
                     server_mods=["mod4", "mod5", "mod6"],
-                    mission_directory="OVERRIDDEN-MISSION"),
+                    mission_directory="OVERRIDDEN-MISSION",
+                    parameters=["-opt1", "-opt2=value"]),
                 "override_some": server_config.BundleConfig(
                     mods=["mod7", "mod8"],
                     server_mods=["mod9"])
@@ -140,6 +141,19 @@ class TestLaunchSettings(unittest.TestCase):
 
         assert settings.mission_directory() == "MISSION"
 
+    def test_parameters_returns_parameters_from_config(self) -> None:
+        settings = launch_settings.LaunchSettings(self.config)
+
+        assert settings.parameters() == []
+
+    def test_parameters_returns_parameters_added_with_add_parameter(self) -> None:
+        settings = launch_settings.LaunchSettings(self.config)
+
+        settings.add_parameter("-opt1")
+        settings.add_parameter("-opt2=value")
+
+        assert settings.parameters() == ["-opt1", "-opt2=value"]
+
     def test_load_bundle_loads_bundle_from_config_when_present_in_config(self) -> None:
         settings = launch_settings.LaunchSettings(self.config)
 
@@ -152,6 +166,7 @@ class TestLaunchSettings(unittest.TestCase):
         assert settings.mods() == ["mod1", "mod2", "mod3"]
         assert settings.server_mods() == ["mod4", "mod5", "mod6"]
         assert settings.mission_directory() == "OVERRIDDEN-MISSION"
+        assert settings.parameters() == ["-opt1", "-opt2=value"]
 
     def test_load_bundle_from_config_only_sets_settings_in_config(self) -> None:
         settings = launch_settings.LaunchSettings(self.config)

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -267,6 +267,20 @@ class TestRunServer(unittest.TestCase):
             f"-servermod=some-mod;P:\\path\\to\\mod;{expected_workshop_mod_path}"
         ])
 
+    def test_passes_extra_parameters_when_added_to_launch_settings(self) -> None:
+        settings = launch_settings.LaunchSettings(self.server_config)
+        settings.add_parameter("-opt1")
+        settings.add_parameter("-opt2=value")
+
+        run_server.run_server(settings, localappdata="localappdata", wait=False)
+
+        self.mock_popen.assert_called_once_with([
+            "server.exe",
+            "-config=config.cfg",
+            "-opt1",
+            "-opt2=value"
+        ])
+
     def test_waits_for_new_script_log_and_streams_it_when_wait_is_true(self) -> None:
         self.mock_newest.return_value = "script_previous.log"
         self.mock_wait_for_new.return_value = "script_new.log"

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -26,6 +26,7 @@ class TestLoad(unittest.TestCase):
             mission_directory=None,
             bundle_path="bundles.py",
             workshop_directory=r"C:\Program Files (x86)\Steam\steamapps\common\DayZ\!Workshop",
+            parameters=[],
             bundles={})
 
     def test_raises_for_other_errors(self) -> None:
@@ -62,6 +63,7 @@ executable = 42
             mission_directory=None,
             bundle_path="bundles.py",
             workshop_directory=r"C:\Program Files (x86)\Steam\steamapps\common\DayZ\!Workshop",
+            parameters=[],
             bundles={})
 
     def test_returns_config_file_settings(self) -> None:
@@ -72,6 +74,7 @@ executable = "EXECUTABLE"
 config = "CONFIG-FILE"
 profile_directory = "PROFILE"
 mission_directory = "MISSION"
+parameters = ["-opt1", "-opt2=value"]
 bundles = "BUNDLES"
 
 [workshop]
@@ -87,6 +90,7 @@ directory = "WORKSHOP-DIRECTORY"
             mission_directory="MISSION",
             bundle_path="BUNDLES",
             workshop_directory="WORKSHOP-DIRECTORY",
+            parameters=["-opt1", "-opt2=value"],
             bundles={})
 
     def test_returns_config_with_bundles_when_present_in_config_file(self) -> None:
@@ -100,6 +104,7 @@ workshop_directory = "OVERRIDDEN-WORKSHOP"
 mods = ["mod1", "mod2", "mod3"]
 server_mods = ["smod1", "smod2", "smod3"]
 mission_directory = "OVERRIDDEN-MISSION"
+parameters = ["-opt1", "-opt2=value"]
 
 [bundle.override_some]
 mods = ["mod1", "mod2"]
@@ -122,7 +127,8 @@ server_mods = "mod3"
                 workshop_directory="OVERRIDDEN-WORKSHOP",
                 mods=["mod1", "mod2", "mod3"],
                 server_mods=["smod1", "smod2", "smod3"],
-                mission_directory="OVERRIDDEN-MISSION"),
+                mission_directory="OVERRIDDEN-MISSION",
+                parameters=["-opt1", "-opt2=value"]),
             "override_some": server_config.BundleConfig(
                 mods=["mod1", "mod2"],
                 server_mods=["mod3"]),


### PR DESCRIPTION
This change adds the ability for users to add arbitrary extra command line parameters (e.g. `-adminLog`, `-limitFPS=...`, [etc.](https://community.bistudio.com/wiki/DayZ:Server_Configuration#Launch_Parameters)) via a `server.toml` config file setting and via bundles.