### PR TITLE
Unbinarize config.bin files when extracting them from PBO archives

### DIFF
--- a/dayz_dev_tools/config_cpp.py
+++ b/dayz_dev_tools/config_cpp.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+import tempfile
+
+
+def bin_to_cpp(bin_content: bytes, executable: str) -> bytes:
+    with tempfile.TemporaryDirectory() as tempdir:
+        bin_path = os.path.join(tempdir, "config.bin")
+        cpp_path = os.path.join(tempdir, "config.cpp")
+
+        with open(bin_path, "w+b") as binfile:
+            binfile.write(bin_content)
+
+        subprocess.run(
+            [
+                executable,
+                "-txt",
+                "-dst", cpp_path,
+                bin_path
+            ],
+            check=True)
+
+        with open(cpp_path, "rb") as cppfile:
+            return cppfile.read()

--- a/dayz_dev_tools/extract_pbo.py
+++ b/dayz_dev_tools/extract_pbo.py
@@ -35,14 +35,17 @@ def _extract_file(
         os.makedirs(os.path.join(*parts[:-1]), exist_ok=True)
 
     if parts[-1] == b"config.bin" and cfgconvert is not None:
+        converted_filename = os.path.join(
+            os.path.dirname(pbofile.normalized_filename()), "config.cpp")
+
         if verbose:
-            print(f"Converting {pbofile.normalized_filename()}")
+            print(f"Converting {pbofile.normalized_filename()} -> {converted_filename}")
 
         buffer = io.BytesIO()
         pbofile.unpack(buffer)
         try:
             cpp_content = config_cpp.bin_to_cpp(buffer.getvalue(), cfgconvert)
-            with open(os.path.join(*parts[:-1], b"config.cpp"), "w+b") as out_file:
+            with open(converted_filename, "w+b") as out_file:
                 out_file.write(cpp_content)
                 return
         except Exception as error:

--- a/dayz_dev_tools/extract_pbo.py
+++ b/dayz_dev_tools/extract_pbo.py
@@ -42,13 +42,13 @@ def _extract_file(
         pbofile.unpack(buffer)
         try:
             cpp_content = config_cpp.bin_to_cpp(buffer.getvalue(), cfgconvert)
-            with open(os.path.join(*parts[:-1], b"config.cpp"), "wb") as out_file:
+            with open(os.path.join(*parts[:-1], b"config.cpp"), "w+b") as out_file:
                 out_file.write(cpp_content)
                 return
         except Exception as error:
             print(f"Failed to convert {pbofile.normalized_filename()}: {error}")
 
-    with open(os.path.join(*parts), "wb") as out_file:
+    with open(os.path.join(*parts), "w+b") as out_file:
         if verbose:
             print(f"Extracting {pbofile.normalized_filename()}")
 

--- a/dayz_dev_tools/tools_directory.py
+++ b/dayz_dev_tools/tools_directory.py
@@ -1,0 +1,42 @@
+import importlib
+import logging
+import typing
+
+
+class _Key:
+    def Close(self) -> None:
+        ...
+
+
+class _WinReg:
+    HKEY_CURRENT_USER: _Key
+
+    def OpenKey(self, key: typing.Any, sub_key: str) -> _Key:
+        ...
+
+    def QueryValueEx(self, key: _Key, value_name: str) -> typing.Tuple[str, int]:
+        ...
+
+
+def tools_directory() -> typing.Optional[str]:
+    try:
+        winreg = typing.cast(_WinReg, importlib.import_module("winreg"))
+    except ModuleNotFoundError:
+        logging.debug("Unable to load 'winreg' module")
+        return None
+
+    key = None
+
+    try:
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\bohemia interactive\Dayz Tools")
+
+        value = winreg.QueryValueEx(key, "path")
+
+        return value[0]
+    except Exception:
+        logging.debug("Unable to read DayZ Tools directory from registry", exc_info=True)
+    finally:
+        if key is not None:
+            key.Close()
+
+    return None

--- a/dayz_dev_tools/unpbo.py
+++ b/dayz_dev_tools/unpbo.py
@@ -1,9 +1,11 @@
 import argparse
+import os
 
 import dayz_dev_tools
 from dayz_dev_tools import extract_pbo
 from dayz_dev_tools import list_pbo
 from dayz_dev_tools import pbo_reader
+from dayz_dev_tools import tools_directory
 
 
 def main() -> None:
@@ -26,8 +28,15 @@ def main() -> None:
             if args.list:
                 list_pbo.list_pbo(reader, verbose=args.verbose)
             else:
+                tools_dir = tools_directory.tools_directory()
+                if tools_dir is None:
+                    cfgconvert = None
+                else:
+                    cfgconvert = os.path.join(tools_dir, "bin", "CfgConvert", "CfgConvert.exe")
+
                 extract_pbo.extract_pbo(
-                    reader, args.files, verbose=args.verbose, deobfuscate=args.deobfuscate)
+                    reader, args.files,
+                    verbose=args.verbose, deobfuscate=args.deobfuscate, cfgconvert=cfgconvert)
     except Exception as error:
         print(f"ERROR: {error}")
 

--- a/dayz_dev_tools/unpbo.py
+++ b/dayz_dev_tools/unpbo.py
@@ -10,15 +10,19 @@ from dayz_dev_tools import tools_directory
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="View or extract a PBO file",
+        description="View or extract a PBO archive",
         epilog="See also: https://community.bistudio.com/wiki/PBO_File_Format")
-    parser.add_argument("-l", "--list", action="store_true", help="List contents of the PBO")
+    parser.add_argument(
+        "-l", "--list", action="store_true", help="List contents of the PBO archive")
+    parser.add_argument(
+        "-b", "--no-convert", action="store_true",
+        help="Do not convert config.bin files to config.cpp files")
     parser.add_argument(
         "-d", "--deobfuscate", action="store_true", help="Attempt to deobfuscate extracted files")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
     parser.add_argument("-V", "--version", action="version", version=dayz_dev_tools.version)
-    parser.add_argument("pbofile", help="The PBO file to read")
-    parser.add_argument("files", nargs="*", help="Files to extract from the PBO")
+    parser.add_argument("pbofile", help="The PBO archive to read")
+    parser.add_argument("files", nargs="*", help="Files to extract from the PBO archive")
     args = parser.parse_args()
 
     try:
@@ -28,11 +32,11 @@ def main() -> None:
             if args.list:
                 list_pbo.list_pbo(reader, verbose=args.verbose)
             else:
-                tools_dir = tools_directory.tools_directory()
-                if tools_dir is None:
-                    cfgconvert = None
-                else:
-                    cfgconvert = os.path.join(tools_dir, "bin", "CfgConvert", "CfgConvert.exe")
+                cfgconvert = None
+                if args.no_convert is False:
+                    tools_dir = tools_directory.tools_directory()
+                    if tools_dir is not None:
+                        cfgconvert = os.path.join(tools_dir, "bin", "CfgConvert", "CfgConvert.exe")
 
                 extract_pbo.extract_pbo(
                     reader, args.files,

--- a/tests/test_config_cpp.py
+++ b/tests/test_config_cpp.py
@@ -1,0 +1,57 @@
+import io
+import os
+import unittest
+from unittest import mock
+
+from dayz_dev_tools import config_cpp
+
+
+class TestBinToCpp(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        temporary_directory_patcher = mock.patch("tempfile.TemporaryDirectory", autospec=True)
+        self.mock_temporary_directory_class = temporary_directory_patcher.start()
+        self.addCleanup(temporary_directory_patcher.stop)
+
+        self.mock_temporary_directory_context = self.mock_temporary_directory_class.return_value
+
+        open_patcher = mock.patch("builtins.open", mock.mock_open())
+        self.mock_open = open_patcher.start()
+        self.addCleanup(open_patcher.stop)
+
+        run_patcher = mock.patch("subprocess.run")
+        self.mock_run = run_patcher.start()
+        self.addCleanup(run_patcher.stop)
+
+    def test_converts_config_bin_to_config_cpp(self) -> None:
+        temp_bin_file = io.BytesIO()
+        temp_cpp_file = io.BytesIO(b"CPP-CONTENT")
+
+        self.mock_temporary_directory_context.__enter__.return_value = "TEMP-DIR"
+
+        self.mock_open.return_value.__enter__.side_effect = [
+            temp_bin_file,
+            temp_cpp_file
+        ]
+
+        out_content = config_cpp.bin_to_cpp(b"BIN-CONTENT", "path/to/cfgconvert.exe")
+
+        assert out_content == b"CPP-CONTENT"
+
+        self.mock_temporary_directory_class.assert_called_once_with()
+
+        assert self.mock_open.call_count == 2
+        assert self.mock_open.call_args_list == [
+            mock.call(os.path.join("TEMP-DIR", "config.bin"), "w+b"),
+            mock.call(os.path.join("TEMP-DIR", "config.cpp"), "rb")
+        ]
+
+        self.mock_run.assert_called_once_with(
+            [
+                "path/to/cfgconvert.exe",
+                "-txt",
+                "-dst", os.path.join("TEMP-DIR", "config.cpp"),
+                os.path.join("TEMP-DIR", "config.bin")
+            ],
+            check=True)

--- a/tests/test_extract_pbo.py
+++ b/tests/test_extract_pbo.py
@@ -57,11 +57,11 @@ class TestExtractPbo(unittest.TestCase):
 
         assert mock_open.call_count == 5
         mock_open.assert_has_calls([
-            mock.call(os.path.join(b"dir1", b"dir2", b"filename.ext"), "wb"),
-            mock.call(os.path.join(b"dir1", b"filename.ext"), "wb"),
-            mock.call(os.path.join(b"dir1", b"dir2", b"dir3", b"filename.ext"), "wb"),
-            mock.call(os.path.join(b"filename.ext"), "wb"),
-            mock.call(os.path.join(b"other-filename.png"), "wb")
+            mock.call(os.path.join(b"dir1", b"dir2", b"filename.ext"), "w+b"),
+            mock.call(os.path.join(b"dir1", b"filename.ext"), "w+b"),
+            mock.call(os.path.join(b"dir1", b"dir2", b"dir3", b"filename.ext"), "w+b"),
+            mock.call(os.path.join(b"filename.ext"), "w+b"),
+            mock.call(os.path.join(b"other-filename.png"), "w+b")
         ], any_order=True)
 
         mock_open.return_value.__enter__.return_value.write.assert_has_calls([
@@ -101,8 +101,8 @@ class TestExtractPbo(unittest.TestCase):
 
         assert mock_open.call_count == 2
         mock_open.assert_has_calls([
-            mock.call(os.path.join(b"filename.ext"), "wb"),
-            mock.call(os.path.join(b"dir1", b"filename.ext"), "wb")
+            mock.call(os.path.join(b"filename.ext"), "w+b"),
+            mock.call(os.path.join(b"dir1", b"filename.ext"), "w+b")
         ], any_order=True)
 
         mock_open.return_value.__enter__.return_value.write.assert_has_calls([
@@ -194,9 +194,9 @@ class TestExtractPbo(unittest.TestCase):
 
         assert mock_open.call_count == 3
         mock_open.assert_has_calls([
-            mock.call(b"obfuscated1", "wb"),
-            mock.call(b"obfuscated2", "wb"),
-            mock.call(b"obfuscated3", "wb")
+            mock.call(b"obfuscated1", "w+b"),
+            mock.call(b"obfuscated2", "w+b"),
+            mock.call(b"obfuscated3", "w+b")
         ], any_order=True)
 
         mock_open.return_value.__enter__.return_value.write.assert_has_calls([
@@ -272,7 +272,7 @@ class TestExtractPbo(unittest.TestCase):
 
         mock_print.assert_not_called()
 
-        mock_open.assert_called_once_with(b"obfuscated1", "wb")
+        mock_open.assert_called_once_with(b"obfuscated1", "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(content)
 
@@ -294,7 +294,7 @@ class TestExtractPbo(unittest.TestCase):
             mock.call("Unable to deobfuscate obfuscated1")
         ])
 
-        mock_open.assert_called_once_with(b"obfuscated1", "wb")
+        mock_open.assert_called_once_with(b"obfuscated1", "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(content)
 
@@ -320,7 +320,7 @@ class TestExtractPbo(unittest.TestCase):
 
         mock_print.assert_not_called()
 
-        mock_open.assert_called_once_with(b"obfuscated1", "wb")
+        mock_open.assert_called_once_with(b"obfuscated1", "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(
             b"NOT OBFUSCATED CONTENT 1"),
@@ -341,7 +341,7 @@ class TestExtractPbo(unittest.TestCase):
 
         self.mock_bin_to_cpp.assert_not_called()
 
-        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.bin"), "wb")
+        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.bin"), "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"1111")
 
@@ -361,7 +361,7 @@ class TestExtractPbo(unittest.TestCase):
 
         self.mock_bin_to_cpp.assert_called_once_with(b"1111", "cppconvert.exe")
 
-        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.cpp"), "wb")
+        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.cpp"), "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"CPP-CONTENT")
 
@@ -381,7 +381,7 @@ class TestExtractPbo(unittest.TestCase):
 
         self.mock_bin_to_cpp.assert_called_once_with(b"1111", "cppconvert.exe")
 
-        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.bin"), "wb")
+        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.bin"), "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"1111")
 

--- a/tests/test_extract_pbo.py
+++ b/tests/test_extract_pbo.py
@@ -361,7 +361,7 @@ class TestExtractPbo(unittest.TestCase):
 
         self.mock_bin_to_cpp.assert_called_once_with(b"1111", "cppconvert.exe")
 
-        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.cpp"), "w+b")
+        mock_open.assert_called_once_with(os.path.join("dir1", "config.cpp"), "w+b")
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"CPP-CONTENT")
 
@@ -397,4 +397,4 @@ class TestExtractPbo(unittest.TestCase):
                 self.mock_pboreader, [], verbose=True, deobfuscate=False,
                 cfgconvert="cppconvert.exe")
 
-        mock_print.assert_called_once_with("Converting dir1\\config.bin")
+        mock_print.assert_called_once_with("Converting dir1\\config.bin -> dir1\\config.cpp")

--- a/tests/test_extract_pbo.py
+++ b/tests/test_extract_pbo.py
@@ -377,7 +377,8 @@ class TestExtractPbo(unittest.TestCase):
                 self.mock_pboreader, [], verbose=False, deobfuscate=False,
                 cfgconvert="cppconvert.exe")
 
-        mock_print.assert_called_once_with("Failed to convert dir1\\config.bin: cfgconvert error")
+        mock_print.assert_called_once_with(
+            f"Failed to convert {os.path.join('dir1', 'config.bin')}: cfgconvert error")
 
         self.mock_bin_to_cpp.assert_called_once_with(b"1111", "cppconvert.exe")
 
@@ -397,4 +398,6 @@ class TestExtractPbo(unittest.TestCase):
                 self.mock_pboreader, [], verbose=True, deobfuscate=False,
                 cfgconvert="cppconvert.exe")
 
-        mock_print.assert_called_once_with("Converting dir1\\config.bin -> dir1\\config.cpp")
+        mock_print.assert_called_once_with(
+            f"Converting {os.path.join('dir1', 'config.bin')}"
+            f" -> {os.path.join('dir1', 'config.cpp')}")

--- a/tests/test_extract_pbo.py
+++ b/tests/test_extract_pbo.py
@@ -17,6 +17,10 @@ class TestExtractPbo(unittest.TestCase):
         self.mock_makedirs = makedirs_patcher.start()
         self.addCleanup(makedirs_patcher.stop)
 
+        bin_to_cpp_patcher = mock.patch("dayz_dev_tools.config_cpp.bin_to_cpp")
+        self.mock_bin_to_cpp = bin_to_cpp_patcher.start()
+        self.addCleanup(bin_to_cpp_patcher.stop)
+
     def create_mock_file(self, filename: bytes, contents: bytes) -> pbo_file.PBOFile:
         def unpack(dest: typing.BinaryIO) -> None:
             dest.write(contents)
@@ -37,7 +41,8 @@ class TestExtractPbo(unittest.TestCase):
         ]
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=False, deobfuscate=False)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=False, cfgconvert=None)
 
         mock_print.assert_not_called()
 
@@ -81,7 +86,7 @@ class TestExtractPbo(unittest.TestCase):
                     os.path.join("filename.ext"),
                     os.path.join("dir1", "filename.ext")
                 ],
-                verbose=False, deobfuscate=False)
+                verbose=False, deobfuscate=False, cfgconvert=None)
 
         mock_print.assert_not_called()
 
@@ -115,7 +120,7 @@ class TestExtractPbo(unittest.TestCase):
                     os.path.join("filename.ext"),
                     os.path.join("dir1", "filename.ext")
                 ],
-                verbose=False, deobfuscate=False)
+                verbose=False, deobfuscate=False, cfgconvert=None)
 
         self.mock_pboreader.file.assert_called_once()
 
@@ -132,7 +137,8 @@ class TestExtractPbo(unittest.TestCase):
         ]
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=True, deobfuscate=False)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=True, deobfuscate=False, cfgconvert=None)
 
         assert mock_print.call_count == 5
         mock_print.assert_has_calls([
@@ -157,7 +163,7 @@ class TestExtractPbo(unittest.TestCase):
                     os.path.join("filename.ext"),
                     os.path.join("dir1", "filename.ext")
                 ],
-                verbose=True, deobfuscate=False)
+                verbose=True, deobfuscate=False, cfgconvert=None)
 
         assert mock_print.call_count == 2
         mock_print.assert_has_calls([
@@ -181,7 +187,8 @@ class TestExtractPbo(unittest.TestCase):
         self.mock_pboreader.file.side_effect = mock_files[3:]
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=False, deobfuscate=True)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=True, cfgconvert=None)
 
         mock_print.assert_not_called()
 
@@ -215,7 +222,8 @@ class TestExtractPbo(unittest.TestCase):
         self.mock_pboreader.prefix.return_value = b"PREFIX"
 
         with mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=False, deobfuscate=True)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=True, cfgconvert=None)
 
         mock_open.return_value.__enter__.return_value.write.assert_called_once_with(
             b"NOT OBFUSCATED CONTENT"),
@@ -239,7 +247,8 @@ class TestExtractPbo(unittest.TestCase):
         ]
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=True, deobfuscate=True)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=True, deobfuscate=True, cfgconvert=None)
 
         assert mock_print.call_count == 4
         mock_print.assert_has_calls([
@@ -258,7 +267,8 @@ class TestExtractPbo(unittest.TestCase):
         self.mock_pboreader.file.return_value = None
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=False, deobfuscate=True)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=True, cfgconvert=None)
 
         mock_print.assert_not_called()
 
@@ -277,7 +287,8 @@ class TestExtractPbo(unittest.TestCase):
         self.mock_pboreader.file.return_value = None
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=True, deobfuscate=True)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=True, deobfuscate=True, cfgconvert=None)
 
         mock_print.assert_has_calls([
             mock.call("Unable to deobfuscate obfuscated1")
@@ -304,7 +315,8 @@ class TestExtractPbo(unittest.TestCase):
             self.create_mock_file(b"not-obfuscated1", b"NOT OBFUSCATED CONTENT 1")
 
         with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
-            extract_pbo.extract_pbo(self.mock_pboreader, [], verbose=False, deobfuscate=True)
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=True, cfgconvert=None)
 
         mock_print.assert_not_called()
 
@@ -314,3 +326,75 @@ class TestExtractPbo(unittest.TestCase):
             b"NOT OBFUSCATED CONTENT 1"),
 
         self.mock_pboreader.file.assert_called_once_with(b"not-obfuscated1")
+
+    def test_does_not_convert_config_bin_files_when_cfgconvert_is_none(self) -> None:
+        mock_open = mock.mock_open()
+        self.mock_pboreader.files.return_value = [
+            self.create_mock_file(b"dir1\\config.bin", b"1111")
+        ]
+
+        with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=False, cfgconvert=None)
+
+        mock_print.assert_not_called()
+
+        self.mock_bin_to_cpp.assert_not_called()
+
+        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.bin"), "wb")
+
+        mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"1111")
+
+    def test_converts_config_bin_files_when_cfgconvert_is_not_none(self) -> None:
+        self.mock_bin_to_cpp.return_value = b"CPP-CONTENT"
+        mock_open = mock.mock_open()
+        self.mock_pboreader.files.return_value = [
+            self.create_mock_file(b"dir1\\config.bin", b"1111")
+        ]
+
+        with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=False,
+                cfgconvert="cppconvert.exe")
+
+        mock_print.assert_not_called()
+
+        self.mock_bin_to_cpp.assert_called_once_with(b"1111", "cppconvert.exe")
+
+        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.cpp"), "wb")
+
+        mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"CPP-CONTENT")
+
+    def test_extracts_unconverted_config_bin_if_convert_to_config_cpp_fails(self) -> None:
+        self.mock_bin_to_cpp.side_effect = Exception("cfgconvert error")
+        mock_open = mock.mock_open()
+        self.mock_pboreader.files.return_value = [
+            self.create_mock_file(b"dir1\\config.bin", b"1111")
+        ]
+
+        with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=False, deobfuscate=False,
+                cfgconvert="cppconvert.exe")
+
+        mock_print.assert_called_once_with("Failed to convert dir1\\config.bin: cfgconvert error")
+
+        self.mock_bin_to_cpp.assert_called_once_with(b"1111", "cppconvert.exe")
+
+        mock_open.assert_called_once_with(os.path.join(b"dir1", b"config.bin"), "wb")
+
+        mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"1111")
+
+    def test_prints_when_converting_config_bin_files(self) -> None:
+        self.mock_bin_to_cpp.return_value = b"CPP-CONTENT"
+        mock_open = mock.mock_open()
+        self.mock_pboreader.files.return_value = [
+            self.create_mock_file(b"dir1\\config.bin", b"1111")
+        ]
+
+        with mock.patch("builtins.print") as mock_print, mock.patch("builtins.open", mock_open):
+            extract_pbo.extract_pbo(
+                self.mock_pboreader, [], verbose=True, deobfuscate=False,
+                cfgconvert="cppconvert.exe")
+
+        mock_print.assert_called_once_with("Converting dir1\\config.bin")

--- a/tests/test_tools_directory.py
+++ b/tests/test_tools_directory.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest import mock
+
+from dayz_dev_tools import tools_directory
+
+
+class TestToolsDirectory(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        import_module_patcher = mock.patch("importlib.import_module")
+        self.mock_import_module = import_module_patcher.start()
+        self.addCleanup(import_module_patcher.stop)
+
+        self.mock_winreg = self.mock_import_module.return_value
+
+    def test_returns_none_when_winreg_module_is_not_available(self) -> None:
+        self.mock_import_module.side_effect = ModuleNotFoundError
+
+        assert tools_directory.tools_directory() is None
+
+    def test_raises_when_importing_winreg_fails_for_other_reasons(self) -> None:
+        self.mock_import_module.side_effect = Exception("other import error")
+
+        with self.assertRaises(Exception) as error:
+            tools_directory.tools_directory()
+
+        assert error.exception == self.mock_import_module.side_effect
+
+    def test_returns_dayz_tools_directory_path_when_present_in_windows_registry(self) -> None:
+        mock_key = self.mock_winreg.OpenKey.return_value
+        self.mock_winreg.QueryValueEx.return_value = ("path/to/dayz/tools", 1)
+
+        assert tools_directory.tools_directory() == "path/to/dayz/tools"
+
+        self.mock_import_module.assert_called_once_with("winreg")
+
+        self.mock_winreg.OpenKey.assert_called_once_with(
+            self.mock_winreg.HKEY_CURRENT_USER, r"Software\bohemia interactive\Dayz Tools")
+
+        self.mock_winreg.QueryValueEx.assert_called_once_with(mock_key, "path")
+
+        mock_key.Close.assert_called_once_with()
+
+    def test_returns_none_when_key_is_not_present_in_registry(self) -> None:
+        self.mock_winreg.OpenKey.side_effect = OSError
+
+        assert tools_directory.tools_directory() is None
+
+        self.mock_winreg.QueryValueEx.assert_not_called()
+
+    def test_closes_key_when_querying_its_value_fails(self) -> None:
+        mock_key = self.mock_winreg.OpenKey.return_value
+        self.mock_winreg.QueryValueEx.side_effect = Exception("query failure")
+
+        assert tools_directory.tools_directory() is None
+
+        mock_key.Close.assert_called_once_with()

--- a/tests/test_unpbo.py
+++ b/tests/test_unpbo.py
@@ -118,6 +118,22 @@ class TestMain(unittest.TestCase):
             self.mock_pboreader, [], verbose=False, deobfuscate=False,
             cfgconvert=os.path.join("TOOLS-DIR", "bin", "CfgConvert", "CfgConvert.exe"))
 
+    def test_does_not_convert_config_bin_files_when_no_convert_option_is_specified(self) -> None:
+        self.mock_tools_directory.return_value = "TOOLS-DIR"
+        mock_open = mock.mock_open()
+
+        with mock.patch("builtins.open", mock_open):
+            main([
+                "ignored",
+                "path/to/filename.ext",
+                "-b"
+            ])
+
+        self.mock_tools_directory.assert_not_called()
+
+        self.mock_extract_pbo.assert_called_once_with(
+            self.mock_pboreader, [], verbose=False, deobfuscate=False, cfgconvert=None)
+
     def test_lists_the_pbo_contents_when_option_is_specified(self) -> None:
         mock_open = mock.mock_open()
         with mock.patch("builtins.open", mock_open):

--- a/tests/test_unpbo.py
+++ b/tests/test_unpbo.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest import mock
 
@@ -12,6 +13,11 @@ main = helpers.call_main(unpbo)
 class TestMain(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
+        tools_directory_patcher = mock.patch(
+            "dayz_dev_tools.tools_directory.tools_directory", return_value=None)
+        self.mock_tools_directory = tools_directory_patcher.start()
+        self.addCleanup(tools_directory_patcher.stop)
+
         extract_pbo_patcher = mock.patch("dayz_dev_tools.extract_pbo.extract_pbo")
         self.mock_extract_pbo = extract_pbo_patcher.start()
         self.addCleanup(extract_pbo_patcher.stop)
@@ -39,8 +45,10 @@ class TestMain(unittest.TestCase):
         self.mock_pboreader_class.assert_called_once_with(
             mock_open.return_value.__enter__.return_value)
 
+        self.mock_tools_directory.assert_called_once_with()
+
         self.mock_extract_pbo.assert_called_once_with(
-            self.mock_pboreader, [], verbose=False, deobfuscate=False)
+            self.mock_pboreader, [], verbose=False, deobfuscate=False, cfgconvert=None)
 
         self.mock_list_pbo.assert_not_called()
 
@@ -62,7 +70,7 @@ class TestMain(unittest.TestCase):
 
         self.mock_extract_pbo.assert_called_once_with(
             self.mock_pboreader, ["file/to/extract/1", "file/to/extract/2", "file/to/extract/3"],
-            verbose=False, deobfuscate=False)
+            verbose=False, deobfuscate=False, cfgconvert=None)
 
         self.mock_list_pbo.assert_not_called()
 
@@ -76,7 +84,7 @@ class TestMain(unittest.TestCase):
             ])
 
         self.mock_extract_pbo.assert_called_once_with(
-            self.mock_pboreader, [], verbose=True, deobfuscate=False)
+            self.mock_pboreader, [], verbose=True, deobfuscate=False, cfgconvert=None)
 
         self.mock_list_pbo.assert_not_called()
 
@@ -90,9 +98,25 @@ class TestMain(unittest.TestCase):
             ])
 
         self.mock_extract_pbo.assert_called_once_with(
-            self.mock_pboreader, [], verbose=False, deobfuscate=True)
+            self.mock_pboreader, [], verbose=False, deobfuscate=True, cfgconvert=None)
 
         self.mock_list_pbo.assert_not_called()
+
+    def test_converts_config_bin_files_while_extracting_when_tools_directory_is_not_none(
+        self
+    ) -> None:
+        self.mock_tools_directory.return_value = "TOOLS-DIR"
+        mock_open = mock.mock_open()
+
+        with mock.patch("builtins.open", mock_open):
+            main([
+                "ignored",
+                "path/to/filename.ext"
+            ])
+
+        self.mock_extract_pbo.assert_called_once_with(
+            self.mock_pboreader, [], verbose=False, deobfuscate=False,
+            cfgconvert=os.path.join("TOOLS-DIR", "bin", "CfgConvert", "CfgConvert.exe"))
 
     def test_lists_the_pbo_contents_when_option_is_specified(self) -> None:
         mock_open = mock.mock_open()
@@ -102,6 +126,8 @@ class TestMain(unittest.TestCase):
                 "-l",
                 "INPUT.pbo"
             ])
+
+        self.mock_tools_directory.assert_not_called()
 
         self.mock_list_pbo.assert_called_once_with(self.mock_pboreader, verbose=False)
 


### PR DESCRIPTION
Resolves #2

Users can pass `-b` or `--no-convert` to skip the `config.bin` ➞ `config.cpp` conversion. I've decided not to provide options for overriding the `CfgConvert.exe` or DayZ Tools directory paths, for now.