### PR TITLE
Search recursively for mod *.bikey files

### DIFF
--- a/dayz_dev_tools/keys.py
+++ b/dayz_dev_tools/keys.py
@@ -1,10 +1,12 @@
+import itertools
 import logging
 import os
 import shutil
 
 
 def copy_keys(source: str, destination: str) -> None:
-    """Search for `*.bikey` (public key) files in one directory and copy them to another directory.
+    """Recursively search for `*.bikey` (public key) files in one directory and copy them to
+    another directory.
 
     :Parameters:
       - `source`: The source directory to be searched for ``*.bikey`` files.
@@ -12,7 +14,10 @@ def copy_keys(source: str, destination: str) -> None:
         This directory will be created if it does not already exist.
     """
     try:
-        keys = [filename for filename in os.listdir(source) if filename.lower().endswith(".bikey")]
+        keys = list(itertools.chain(*[
+            [os.path.join(root, file) for file in files if file.lower().endswith(".bikey")]
+            for root, _, files in os.walk(source)
+        ]))
     except FileNotFoundError:
         logging.debug(f"Error when searching for *.bikey files to copy at {source}", exc_info=True)
         keys = []
@@ -24,4 +29,4 @@ def copy_keys(source: str, destination: str) -> None:
     os.makedirs(destination, exist_ok=True)
 
     for key in keys:
-        shutil.copy2(os.path.join(source, key), destination)
+        shutil.copy2(key, destination)

--- a/dayz_dev_tools/keys.py
+++ b/dayz_dev_tools/keys.py
@@ -14,10 +14,10 @@ def copy_keys(source: str, destination: str) -> None:
         This directory will be created if it does not already exist.
     """
     try:
-        keys = list(itertools.chain(*[
+        keys = list(itertools.chain.from_iterable(
             [os.path.join(root, file) for file in files if file.lower().endswith(".bikey")]
             for root, _, files in os.walk(source)
-        ]))
+        ))
     except FileNotFoundError:
         logging.debug(f"Error when searching for *.bikey files to copy at {source}", exc_info=True)
         keys = []

--- a/dayz_dev_tools/run_server.py
+++ b/dayz_dev_tools/run_server.py
@@ -32,7 +32,7 @@ def _resolve_mod(mod: str, workshop_directory: str) -> str:
 
 def _copy_keys(mod_dirs: typing.List[str], keys_dir: str) -> None:
     for mod_dir in mod_dirs:
-        keys.copy_keys(os.path.join(mod_dir, "keys"), keys_dir)
+        keys.copy_keys(mod_dir, keys_dir)
 
 
 def _mod_parameter(option: str, mods: typing.List[str], workshop_directory: str) -> str:

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -9,9 +9,9 @@ class TestCopyKeys(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        listdir_patcher = mock.patch("os.listdir")
-        self.mock_listdir = listdir_patcher.start()
-        self.addCleanup(listdir_patcher.stop)
+        walk_patcher = mock.patch("os.walk")
+        self.mock_walk = walk_patcher.start()
+        self.addCleanup(walk_patcher.stop)
 
         makedirs_patcher = mock.patch("os.makedirs")
         self.mock_makedirs = makedirs_patcher.start()
@@ -22,30 +22,27 @@ class TestCopyKeys(unittest.TestCase):
         self.addCleanup(copy2_patcher.stop)
 
     def test_copies_bikey_files_from_source_directory_to_destination_directory(self) -> None:
-        self.mock_listdir.return_value = [
-            "ignored",
-            "file1.bikey",
-            "also-ignored",
-            "FILE2.BIKEY",
-            "another-ignored",
-            "file3.bikey",
-            "finally-ignored"
-        ]
+        self.mock_walk.return_value = iter([
+            ("root1", ["ignored"], ["ignored", "file1.bikey"]),
+            ("root2", ["ignored.bikey"], ["also-ignored", "FILE2.BIKEY", "file3.bikey"]),
+            ("root3", ["ignored"], ["another-ignored", "file4.bikey", "finally-ignored"])
+        ])
 
         keys.copy_keys("source", "destination")
 
-        self.mock_listdir.assert_called_once_with("source")
+        self.mock_walk.assert_called_once_with("source")
 
         self.mock_makedirs.assert_called_once_with("destination", exist_ok=True)
 
         self.mock_copy2.assert_has_calls([
-            mock.call(os.path.join("source", "file1.bikey"), "destination"),
-            mock.call(os.path.join("source", "FILE2.BIKEY"), "destination"),
-            mock.call(os.path.join("source", "file3.bikey"), "destination")
+            mock.call(os.path.join("root1", "file1.bikey"), "destination"),
+            mock.call(os.path.join("root2", "FILE2.BIKEY"), "destination"),
+            mock.call(os.path.join("root2", "file3.bikey"), "destination"),
+            mock.call(os.path.join("root3", "file4.bikey"), "destination")
         ])
 
     def test_does_nothing_if_the_source_directory_does_not_exist(self) -> None:
-        self.mock_listdir.side_effect = FileNotFoundError
+        self.mock_walk.side_effect = FileNotFoundError
 
         keys.copy_keys("source", "destination")
 
@@ -54,17 +51,17 @@ class TestCopyKeys(unittest.TestCase):
         self.mock_copy2.assert_not_called()
 
     def test_raises_for_other_errors(self) -> None:
-        self.mock_listdir.side_effect = Exception("other listdir error")
+        expected_error = Exception("other walk error")
+        self.mock_walk.side_effect = expected_error
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(Exception) as error:
             keys.copy_keys("source", "destination")
 
+        assert error.exception is expected_error
+
     def test_does_nothing_if_the_source_directory_contains_no_bikey_files(self) -> None:
-        self.mock_listdir.return_value = [
-            "ignored",
-            "also-ignored",
-            "another-ignored",
-            "finally-ignored"
+        self.mock_walk.return_value = [
+            ("root", [], [])
         ]
 
         keys.copy_keys("source", "destination")

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -252,9 +252,9 @@ class TestRunServer(unittest.TestCase):
         ])
 
         self.mock_copy_keys.assert_has_calls([
-            mock.call(os.path.join("some-mod", "keys"), "keys"),
-            mock.call(os.path.join(r"P:\path\to\mod", "keys"), "keys"),
-            mock.call(os.path.join(expected_workshop_mod_path, "keys"), "keys")
+            mock.call("some-mod", "keys"),
+            mock.call(r"P:\path\to\mod", "keys"),
+            mock.call(expected_workshop_mod_path, "keys")
         ])
 
         self.mock_popen.assert_called_once_with(
@@ -285,9 +285,9 @@ class TestRunServer(unittest.TestCase):
         ])
 
         self.mock_copy_keys.assert_has_calls([
-            mock.call(os.path.join("some-mod", "keys"), "keys"),
-            mock.call(os.path.join(r"P:\path\to\mod", "keys"), "keys"),
-            mock.call(os.path.join(expected_workshop_mod_path, "keys"), "keys")
+            mock.call("some-mod", "keys"),
+            mock.call(r"P:\path\to\mod", "keys"),
+            mock.call(expected_workshop_mod_path, "keys")
         ])
 
         self.mock_popen.assert_called_once_with(


### PR DESCRIPTION
This resolves #22 by recursively searching for `*.bikey` files, instead of looking for the keys in specific subdirectories.