### PR TITLE
Add Python 3.11 Support

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         architecture: [x86, x64]
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         architecture: [x86, x64]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Games/Entertainment :: First Person Shooters",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Utilities",


### PR DESCRIPTION
Python 3.11 was released recently. Let's include it in the CI builds and build wheels for it when publishing releases.