### PR TITLE
Fix deprecation warning

### DIFF
--- a/tests/fixtures/bad_filename
+++ b/tests/fixtures/bad_filename
@@ -1,0 +1,5 @@
+from dayz_dev_tools import launch_settings
+
+
+def bundle1(settings: launch_settings.LaunchSettings) -> None:
+    pass

--- a/tests/test_launch_settings.py
+++ b/tests/test_launch_settings.py
@@ -217,7 +217,16 @@ class TestLaunchSettings(unittest.TestCase):
         mock_bundle1.assert_not_called()
 
     def test_load_bundle_raises_if_bundle_path_is_invalid(self) -> None:
-        self.config.bundle_path = "invalid"
+        self.config.bundle_path = "invalid.py"
+
+        settings = launch_settings.LaunchSettings(self.config)
+
+        with self.assertRaises(Exception):
+            settings.load_bundle("does_not_matter")
+
+    def test_load_bundle_raises_if_bundle_filename_missing_extension(self) -> None:
+        self.config.bundle_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "bad_filename")
 
         settings = launch_settings.LaunchSettings(self.config)
 


### PR DESCRIPTION
The `LaunchSettings` class is using a deprecated method from `importlib`, resulting in warnings when running the code:
```
tests/test_launch_settings.py: 27 warnings
tests/test_run_server.py: 15 warnings
  <frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
```

This fixes the warning by using `exec_module` instead of `load_module`.