### PR TITLE
Upgrade Pydantic to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
-    "pydantic>=2.5.0",
+    "pydantic>=2.8.2",
     "tomli>=2.0.0"
 ]
 keywords = ["dayz", "tools", "pbo", "server"]


### PR DESCRIPTION
This should allow Python 3.13 builds to be added to CI.