### PR TITLE
Handle bad character encodings in terminal output

### DIFF
--- a/dayz_dev_tools/unpbo.py
+++ b/dayz_dev_tools/unpbo.py
@@ -29,6 +29,10 @@ def main() -> None:
     parser.add_argument("files", nargs="*", help="Files to extract from the PBO archive")
     args = parser.parse_args()
 
+    # Obfuscated files sometimes use characters that are incompatible with the terminal's encoding
+    sys.stdout.reconfigure(errors="replace")  # type: ignore[union-attr]
+    sys.stderr.reconfigure(errors="replace")  # type: ignore[union-attr]
+
     logging_configuration.configure_logging(debug=args.debug)
 
     try:

--- a/tests/test_unpbo.py
+++ b/tests/test_unpbo.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 from unittest import mock
 
@@ -36,6 +37,16 @@ class TestMain(unittest.TestCase):
 
         self.mock_pboreader = self.mock_pboreader_class.return_value
 
+        self.original_stdout_errors = sys.stdout.errors
+        self.original_stderr_errors = sys.stderr.errors
+        sys.stdout.reconfigure(errors="strict")  # type: ignore[union-attr]
+        sys.stderr.reconfigure(errors="strict")  # type: ignore[union-attr]
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        sys.stdout.reconfigure(errors=self.original_stdout_errors)  # type: ignore[union-attr]
+        sys.stderr.reconfigure(errors=self.original_stderr_errors)  # type: ignore[union-attr]
+
     def test_parses_args_and_extracts_pbo(self) -> None:
         mock_open = mock.mock_open()
         with mock.patch("builtins.open", mock_open):
@@ -43,6 +54,9 @@ class TestMain(unittest.TestCase):
                 "ignored",
                 "path/to/filename.ext"
             ])
+
+        assert "replace" == sys.stdout.errors
+        assert "replace" == sys.stderr.errors
 
         self.mock_configure_logging.assert_called_once_with(debug=False)
 


### PR DESCRIPTION
This works around an issue where the `unpbo` command errors due to it trying to print characters that are incompatible with the terminal's encoding:

```
Traceback (most recent call last):
  File "[.................................]\dayz_dev_tools\unpbo.py", line 39, in main
    list_pbo.list_pbo(reader, verbose=args.verbose)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[.................................]\dayz_dev_tools\list_pbo.py", line 18, in list_pbo
    print(f"{key.decode(errors='replace')} = {value.decode(errors='replace')}")
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[..............]\AppData\Local\Programs\Python\Python313\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-5: character maps to <undefined>
```