### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         architecture: [x86, x64]
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         architecture: [x86, x64]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ manager:
 pip install dayz-dev-tools
 ```
 
-DayZ Dev Tools can be run on Windows or Linux but Python 3.9 or higher is
+DayZ Dev Tools can be run on Windows or Linux but Python 3.10 or higher is
 required.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,5 +16,5 @@ manager.
 
    pip install dayz-dev-tools
 
-DayZ Dev Tools can be run on Windows or Linux but Python 3.9 or higher is
+DayZ Dev Tools can be run on Windows or Linux but Python 3.10 or higher is
 required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Useful tools for DayZ mod developers."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.8.2",
     "tomli>=2.0.0; python_version<'3.11'"
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Support for Python 3.9 was ended on 2025-10-31